### PR TITLE
add catalog api integration

### DIFF
--- a/src/components/contexts/CatalogContext/CatalogProvider.js
+++ b/src/components/contexts/CatalogContext/CatalogProvider.js
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react'
+import { useDispatch as useReduxDispatch, useSelector } from 'react-redux'
+import { node } from 'prop-types'
+
+import { receiveCatalog, requestCatalog } from '@fashionista/store/thunks'
+import catalogRequest from '@fashionista/services/catalogRequest'
+import CatalogContext from './'
+
+const propTypes = {
+  children: node.isRequired
+}
+
+export default function CatalogProvider ({ children }) {
+  const dispatch = useReduxDispatch()
+  const catalog = useSelector(state => state.catalog)
+
+  useEffect(() => {
+    async function fetchCatalog () {
+      const payload = await catalogRequest()
+
+      dispatch(receiveCatalog({ ...payload }))
+    }
+
+    dispatch(requestCatalog())
+    fetchCatalog()
+  }, [dispatch])
+
+  return (
+    <CatalogContext.Provider value={catalog}>
+      {children}
+    </CatalogContext.Provider>
+  )
+}
+
+CatalogProvider.propTypes = propTypes

--- a/src/components/contexts/CatalogContext/index.js
+++ b/src/components/contexts/CatalogContext/index.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export default createContext()

--- a/src/components/contexts/index.js
+++ b/src/components/contexts/index.js
@@ -1,0 +1,2 @@
+export { default as CatalogContext } from './CatalogContext'
+export { default as CatalogProvider } from './CatalogContext/CatalogProvider'

--- a/src/services/catalogRequest.js
+++ b/src/services/catalogRequest.js
@@ -1,0 +1,38 @@
+const catalogApi = {
+  url:
+    process.env.CATALOG_API ||
+    'https://5e9935925eabe7001681c856.mockapi.io/api/v1/catalog',
+  config: {
+    method: 'GET',
+    mode: 'cors'
+  }
+}
+
+export default function catalogRequest () {
+  const { url, config } = catalogApi
+
+  function handleError (failedResponse) {
+    const { statusText: message, status } = failedResponse
+
+    return {
+      error: {
+        message,
+        status
+      },
+      products: []
+    }
+  }
+
+  async function handleSuccess (productsList) {
+    return {
+      error: false,
+      products: [...productsList]
+    }
+  }
+
+  return window.fetch(url, config).then(async response => {
+    const data = await response.json()
+
+    return response.ok ? handleSuccess(data) : handleError(response)
+  })
+}

--- a/src/store/reducers.js
+++ b/src/store/reducers.js
@@ -1,1 +1,7 @@
-export default {}
+import { catalogReducer } from './slices/catalogSlice'
+
+export { catalogReducer }
+
+export default {
+  catalog: catalogReducer
+}

--- a/src/store/slices/catalogSlice.js
+++ b/src/store/slices/catalogSlice.js
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+const catalogSlice = createSlice({
+  name: 'catalog',
+  reducers: {
+    requestCatalog: state => {
+      state.status = 'pending'
+    },
+    receiveCatalog: (state, action) => {
+      state.status = !action.payload.error ? 'resolved' : 'rejected'
+      state.products = action.payload.products
+    }
+  },
+  initialState: {
+    status: 'idle',
+    error: false,
+    products: []
+  }
+})
+
+export const catalogReducer = catalogSlice.reducer
+export const catalogThunks = catalogSlice.actions

--- a/src/store/thunks.js
+++ b/src/store/thunks.js
@@ -1,0 +1,3 @@
+import { catalogThunks } from './slices/catalogSlice'
+
+export const { receiveCatalog, requestCatalog } = catalogThunks


### PR DESCRIPTION
**Regra que visa cumprir**
* O estado global da aplicação deverá ser gerenciado com Redux
* Deve consumir a API do catálogo de produtos

**O que foi feito**
* Adiciona serviço para requisição HTTP à api de catálogo dos produtos
* Adiciona o contexto `Catalog` para gerenciar a requisição e atualização da store
* Adiciona as actions necessárias para atualizar a store
* Disponibiliza o catálogo de produtos para toda a aplicação, efetuando a requisição no primeiro load e mantendo os dados na store